### PR TITLE
chore: fix typos

### DIFF
--- a/examples/authz/src/codegen/confio/proofs.ts
+++ b/examples/authz/src/codegen/confio/proofs.ts
@@ -153,7 +153,7 @@ export function lengthOpToJSON(object: LengthOp): string {
 }
 /**
  * ExistenceProof takes a key and a value and a set of steps to perform on it.
- * The result of peforming all these steps will provide a "root hash", which can
+ * The result of performing all these steps will provide a "root hash", which can
  * be compared to the value in a header.
  * 
  * Since it is computationally infeasible to produce a hash collission for any of the used
@@ -184,7 +184,7 @@ export interface ExistenceProofProtoMsg {
 }
 /**
  * ExistenceProof takes a key and a value and a set of steps to perform on it.
- * The result of peforming all these steps will provide a "root hash", which can
+ * The result of performing all these steps will provide a "root hash", which can
  * be compared to the value in a header.
  * 
  * Since it is computationally infeasible to produce a hash collission for any of the used
@@ -215,7 +215,7 @@ export interface ExistenceProofAminoMsg {
 }
 /**
  * ExistenceProof takes a key and a value and a set of steps to perform on it.
- * The result of peforming all these steps will provide a "root hash", which can
+ * The result of performing all these steps will provide a "root hash", which can
  * be compared to the value in a header.
  * 
  * Since it is computationally infeasible to produce a hash collission for any of the used
@@ -476,7 +476,7 @@ export interface InnerOpSDKType {
  * 
  * As demonstrated in tests, if we don't fix the algorithm used to calculate the
  * LeafHash for a given tree, there are many possible key-value pairs that can
- * generate a given hash (by interpretting the preimage differently).
+ * generate a given hash (by interpreting the preimage differently).
  * We need this for proper security, requires client knows a priori what
  * tree format server uses. But not in code, rather a configuration object.
  */
@@ -504,7 +504,7 @@ export interface ProofSpecProtoMsg {
  * 
  * As demonstrated in tests, if we don't fix the algorithm used to calculate the
  * LeafHash for a given tree, there are many possible key-value pairs that can
- * generate a given hash (by interpretting the preimage differently).
+ * generate a given hash (by interpreting the preimage differently).
  * We need this for proper security, requires client knows a priori what
  * tree format server uses. But not in code, rather a configuration object.
  */
@@ -532,7 +532,7 @@ export interface ProofSpecAminoMsg {
  * 
  * As demonstrated in tests, if we don't fix the algorithm used to calculate the
  * LeafHash for a given tree, there are many possible key-value pairs that can
- * generate a given hash (by interpretting the preimage differently).
+ * generate a given hash (by interpreting the preimage differently).
  * We need this for proper security, requires client knows a priori what
  * tree format server uses. But not in code, rather a configuration object.
  */

--- a/examples/authz/types/codegen/confio/proofs.d.ts
+++ b/examples/authz/types/codegen/confio/proofs.d.ts
@@ -48,7 +48,7 @@ export declare function lengthOpFromJSON(object: any): LengthOp;
 export declare function lengthOpToJSON(object: LengthOp): string;
 /**
  * ExistenceProof takes a key and a value and a set of steps to perform on it.
- * The result of peforming all these steps will provide a "root hash", which can
+ * The result of performing all these steps will provide a "root hash", which can
  * be compared to the value in a header.
  *
  * Since it is computationally infeasible to produce a hash collission for any of the used
@@ -79,7 +79,7 @@ export interface ExistenceProofProtoMsg {
 }
 /**
  * ExistenceProof takes a key and a value and a set of steps to perform on it.
- * The result of peforming all these steps will provide a "root hash", which can
+ * The result of performing all these steps will provide a "root hash", which can
  * be compared to the value in a header.
  *
  * Since it is computationally infeasible to produce a hash collission for any of the used
@@ -110,7 +110,7 @@ export interface ExistenceProofAminoMsg {
 }
 /**
  * ExistenceProof takes a key and a value and a set of steps to perform on it.
- * The result of peforming all these steps will provide a "root hash", which can
+ * The result of performing all these steps will provide a "root hash", which can
  * be compared to the value in a header.
  *
  * Since it is computationally infeasible to produce a hash collission for any of the used
@@ -371,7 +371,7 @@ export interface InnerOpSDKType {
  *
  * As demonstrated in tests, if we don't fix the algorithm used to calculate the
  * LeafHash for a given tree, there are many possible key-value pairs that can
- * generate a given hash (by interpretting the preimage differently).
+ * generate a given hash (by interpreting the preimage differently).
  * We need this for proper security, requires client knows a priori what
  * tree format server uses. But not in code, rather a configuration object.
  */
@@ -399,7 +399,7 @@ export interface ProofSpecProtoMsg {
  *
  * As demonstrated in tests, if we don't fix the algorithm used to calculate the
  * LeafHash for a given tree, there are many possible key-value pairs that can
- * generate a given hash (by interpretting the preimage differently).
+ * generate a given hash (by interpreting the preimage differently).
  * We need this for proper security, requires client knows a priori what
  * tree format server uses. But not in code, rather a configuration object.
  */
@@ -427,7 +427,7 @@ export interface ProofSpecAminoMsg {
  *
  * As demonstrated in tests, if we don't fix the algorithm used to calculate the
  * LeafHash for a given tree, there are many possible key-value pairs that can
- * generate a given hash (by interpretting the preimage differently).
+ * generate a given hash (by interpreting the preimage differently).
  * We need this for proper security, requires client knows a priori what
  * tree format server uses. But not in code, rather a configuration object.
  */

--- a/examples/grpc-web-grpc-gateway/codegen_grpc_gateway/confio/proofs.ts
+++ b/examples/grpc-web-grpc-gateway/codegen_grpc_gateway/confio/proofs.ts
@@ -151,7 +151,7 @@ export function lengthOpToJSON(object: LengthOp): string {
 }
 /**
  * ExistenceProof takes a key and a value and a set of steps to perform on it.
- * The result of peforming all these steps will provide a "root hash", which can
+ * The result of performing all these steps will provide a "root hash", which can
  * be compared to the value in a header.
  * 
  * Since it is computationally infeasible to produce a hash collission for any of the used
@@ -182,7 +182,7 @@ export interface ExistenceProofProtoMsg {
 }
 /**
  * ExistenceProof takes a key and a value and a set of steps to perform on it.
- * The result of peforming all these steps will provide a "root hash", which can
+ * The result of performing all these steps will provide a "root hash", which can
  * be compared to the value in a header.
  * 
  * Since it is computationally infeasible to produce a hash collission for any of the used
@@ -213,7 +213,7 @@ export interface ExistenceProofAminoMsg {
 }
 /**
  * ExistenceProof takes a key and a value and a set of steps to perform on it.
- * The result of peforming all these steps will provide a "root hash", which can
+ * The result of performing all these steps will provide a "root hash", which can
  * be compared to the value in a header.
  * 
  * Since it is computationally infeasible to produce a hash collission for any of the used
@@ -474,7 +474,7 @@ export interface InnerOpSDKType {
  * 
  * As demonstrated in tests, if we don't fix the algorithm used to calculate the
  * LeafHash for a given tree, there are many possible key-value pairs that can
- * generate a given hash (by interpretting the preimage differently).
+ * generate a given hash (by interpreting the preimage differently).
  * We need this for proper security, requires client knows a priori what
  * tree format server uses. But not in code, rather a configuration object.
  */
@@ -502,7 +502,7 @@ export interface ProofSpecProtoMsg {
  * 
  * As demonstrated in tests, if we don't fix the algorithm used to calculate the
  * LeafHash for a given tree, there are many possible key-value pairs that can
- * generate a given hash (by interpretting the preimage differently).
+ * generate a given hash (by interpreting the preimage differently).
  * We need this for proper security, requires client knows a priori what
  * tree format server uses. But not in code, rather a configuration object.
  */
@@ -530,7 +530,7 @@ export interface ProofSpecAminoMsg {
  * 
  * As demonstrated in tests, if we don't fix the algorithm used to calculate the
  * LeafHash for a given tree, there are many possible key-value pairs that can
- * generate a given hash (by interpretting the preimage differently).
+ * generate a given hash (by interpreting the preimage differently).
  * We need this for proper security, requires client knows a priori what
  * tree format server uses. But not in code, rather a configuration object.
  */

--- a/examples/grpc-web-grpc-gateway/codegen_grpc_web/confio/proofs.ts
+++ b/examples/grpc-web-grpc-gateway/codegen_grpc_web/confio/proofs.ts
@@ -151,7 +151,7 @@ export function lengthOpToJSON(object: LengthOp): string {
 }
 /**
  * ExistenceProof takes a key and a value and a set of steps to perform on it.
- * The result of peforming all these steps will provide a "root hash", which can
+ * The result of performing all these steps will provide a "root hash", which can
  * be compared to the value in a header.
  * 
  * Since it is computationally infeasible to produce a hash collission for any of the used
@@ -182,7 +182,7 @@ export interface ExistenceProofProtoMsg {
 }
 /**
  * ExistenceProof takes a key and a value and a set of steps to perform on it.
- * The result of peforming all these steps will provide a "root hash", which can
+ * The result of performing all these steps will provide a "root hash", which can
  * be compared to the value in a header.
  * 
  * Since it is computationally infeasible to produce a hash collission for any of the used
@@ -213,7 +213,7 @@ export interface ExistenceProofAminoMsg {
 }
 /**
  * ExistenceProof takes a key and a value and a set of steps to perform on it.
- * The result of peforming all these steps will provide a "root hash", which can
+ * The result of performing all these steps will provide a "root hash", which can
  * be compared to the value in a header.
  * 
  * Since it is computationally infeasible to produce a hash collission for any of the used
@@ -474,7 +474,7 @@ export interface InnerOpSDKType {
  * 
  * As demonstrated in tests, if we don't fix the algorithm used to calculate the
  * LeafHash for a given tree, there are many possible key-value pairs that can
- * generate a given hash (by interpretting the preimage differently).
+ * generate a given hash (by interpreting the preimage differently).
  * We need this for proper security, requires client knows a priori what
  * tree format server uses. But not in code, rather a configuration object.
  */
@@ -502,7 +502,7 @@ export interface ProofSpecProtoMsg {
  * 
  * As demonstrated in tests, if we don't fix the algorithm used to calculate the
  * LeafHash for a given tree, there are many possible key-value pairs that can
- * generate a given hash (by interpretting the preimage differently).
+ * generate a given hash (by interpreting the preimage differently).
  * We need this for proper security, requires client knows a priori what
  * tree format server uses. But not in code, rather a configuration object.
  */
@@ -530,7 +530,7 @@ export interface ProofSpecAminoMsg {
  * 
  * As demonstrated in tests, if we don't fix the algorithm used to calculate the
  * LeafHash for a given tree, there are many possible key-value pairs that can
- * generate a given hash (by interpretting the preimage differently).
+ * generate a given hash (by interpreting the preimage differently).
  * We need this for proper security, requires client knows a priori what
  * tree format server uses. But not in code, rather a configuration object.
  */

--- a/examples/telescope-with-contracts/src/codegen/confio/proofs.ts
+++ b/examples/telescope-with-contracts/src/codegen/confio/proofs.ts
@@ -147,7 +147,7 @@ export function lengthOpToJSON(object: LengthOp): string {
 }
 /**
  * ExistenceProof takes a key and a value and a set of steps to perform on it.
- * The result of peforming all these steps will provide a "root hash", which can
+ * The result of performing all these steps will provide a "root hash", which can
  * be compared to the value in a header.
  * 
  * Since it is computationally infeasible to produce a hash collission for any of the used
@@ -174,7 +174,7 @@ export interface ExistenceProof {
 }
 /**
  * ExistenceProof takes a key and a value and a set of steps to perform on it.
- * The result of peforming all these steps will provide a "root hash", which can
+ * The result of performing all these steps will provide a "root hash", which can
  * be compared to the value in a header.
  * 
  * Since it is computationally infeasible to produce a hash collission for any of the used
@@ -336,7 +336,7 @@ export interface InnerOpSDKType {
  * 
  * As demonstrated in tests, if we don't fix the algorithm used to calculate the
  * LeafHash for a given tree, there are many possible key-value pairs that can
- * generate a given hash (by interpretting the preimage differently).
+ * generate a given hash (by interpreting the preimage differently).
  * We need this for proper security, requires client knows a priori what
  * tree format server uses. But not in code, rather a configuration object.
  */
@@ -360,7 +360,7 @@ export interface ProofSpec {
  * 
  * As demonstrated in tests, if we don't fix the algorithm used to calculate the
  * LeafHash for a given tree, there are many possible key-value pairs that can
- * generate a given hash (by interpretting the preimage differently).
+ * generate a given hash (by interpreting the preimage differently).
  * We need this for proper security, requires client knows a priori what
  * tree format server uses. But not in code, rather a configuration object.
  */

--- a/examples/telescope/src/codegen/confio/proofs.ts
+++ b/examples/telescope/src/codegen/confio/proofs.ts
@@ -149,7 +149,7 @@ export function lengthOpToJSON(object: LengthOp): string {
 }
 /**
  * ExistenceProof takes a key and a value and a set of steps to perform on it.
- * The result of peforming all these steps will provide a "root hash", which can
+ * The result of performing all these steps will provide a "root hash", which can
  * be compared to the value in a header.
  * 
  * Since it is computationally infeasible to produce a hash collission for any of the used
@@ -180,7 +180,7 @@ export interface ExistenceProofProtoMsg {
 }
 /**
  * ExistenceProof takes a key and a value and a set of steps to perform on it.
- * The result of peforming all these steps will provide a "root hash", which can
+ * The result of performing all these steps will provide a "root hash", which can
  * be compared to the value in a header.
  * 
  * Since it is computationally infeasible to produce a hash collission for any of the used
@@ -211,7 +211,7 @@ export interface ExistenceProofAminoMsg {
 }
 /**
  * ExistenceProof takes a key and a value and a set of steps to perform on it.
- * The result of peforming all these steps will provide a "root hash", which can
+ * The result of performing all these steps will provide a "root hash", which can
  * be compared to the value in a header.
  * 
  * Since it is computationally infeasible to produce a hash collission for any of the used
@@ -472,7 +472,7 @@ export interface InnerOpSDKType {
  * 
  * As demonstrated in tests, if we don't fix the algorithm used to calculate the
  * LeafHash for a given tree, there are many possible key-value pairs that can
- * generate a given hash (by interpretting the preimage differently).
+ * generate a given hash (by interpreting the preimage differently).
  * We need this for proper security, requires client knows a priori what
  * tree format server uses. But not in code, rather a configuration object.
  */
@@ -500,7 +500,7 @@ export interface ProofSpecProtoMsg {
  * 
  * As demonstrated in tests, if we don't fix the algorithm used to calculate the
  * LeafHash for a given tree, there are many possible key-value pairs that can
- * generate a given hash (by interpretting the preimage differently).
+ * generate a given hash (by interpreting the preimage differently).
  * We need this for proper security, requires client knows a priori what
  * tree format server uses. But not in code, rather a configuration object.
  */
@@ -528,7 +528,7 @@ export interface ProofSpecAminoMsg {
  * 
  * As demonstrated in tests, if we don't fix the algorithm used to calculate the
  * LeafHash for a given tree, there are many possible key-value pairs that can
- * generate a given hash (by interpretting the preimage differently).
+ * generate a given hash (by interpreting the preimage differently).
  * We need this for proper security, requires client knows a priori what
  * tree format server uses. But not in code, rather a configuration object.
  */


### PR DESCRIPTION
## Description

This pull request fixes minor typographical errors in the `examples/authz/src/codegen/confio/proofs.ts` file:

- Corrected **"peforming"** to **"performing"** in multiple documentation comments.
- Corrected **"interperting"** to **"interpreting"** in documentation comments.

These changes improve the clarity and professionalism of the code documentation.

> **Note:** No functional code was changed.